### PR TITLE
Grupo Facturación Franquicias: categoría propia en lugar de Contabilidad

### DIFF
--- a/pos_sale_order_sync_autoinvoice/__manifest__.py
+++ b/pos_sale_order_sync_autoinvoice/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "POS Sale Order Sync - Auto Invoice",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.3.0",
     "category": "Point of Sale",
     "author": "PrimateUY",
     "license": "LGPL-3",

--- a/pos_sale_order_sync_autoinvoice/security/security.xml
+++ b/pos_sale_order_sync_autoinvoice/security/security.xml
@@ -4,10 +4,41 @@
         <!-- Grupo de visibilidad de la acción "Facturar por límite de líneas".
              NO debe implicar base.group_system: es un grupo de acceso a la
              acción, no un perfil de administrador. Los miembros se asignan
-             desde Ajustes > Usuarios. -->
+             desde Ajustes > Usuarios.
+
+             CATEGORÍA PROPIA a propósito. Antes colgaba de
+             base.module_category_accounting_accounting, pero Odoo fuerza esa
+             categoría a desplegable de opción única mediante un caso especial
+             hardcodeado en get_groups_by_application()
+             (odoo/addons/base/models/res_users.py). Eso hacía que este permiso
+             compitiera con "Facturación" y con "Administrador de facturación",
+             que NO lo implican: elegir cualquiera de ellos borraba este grupo
+             en silencio. Es un permiso de acción de POS, no un nivel contable.
+
+             Tampoco sirve dejarlo sin category_id: los grupos sin categoría se
+             agrupan en un bloque que la vista de usuario envuelve con
+             groups="base.group_no_one", así que solo se ven en modo
+             desarrollador — y quien administra usuarios en FORUM no lo usa.
+
+             Con categoría propia y un solo grupo dentro, el orden es total y se
+             dibuja como un desplegable de dos opciones (vacío / el grupo),
+             visible en modo normal y sin colisionar con Contabilidad.
+
+             El parent_id define bajo qué encabezado se agrupa el bloque: sin
+             padre, get_groups_by_application() le asigna (100, 'Other') y el
+             permiso termina en el bloque OTHER. Colgándolo de
+             base.module_category_accounting queda dentro del bloque ACCOUNTING,
+             junto a "Contabilidad" y "Banco", pero como desplegable aparte. -->
+        <record id="module_category_franquicias" model="ir.module.category">
+            <field name="name">Franquicias</field>
+            <field name="description">Permisos del circuito de facturación entre matriz y franquicias.</field>
+            <field name="parent_id" ref="base.module_category_accounting"/>
+            <field name="sequence">25</field>
+        </record>
+
         <record id="group_facturacion_franquicias" model="res.groups">
             <field name="name">Facturación Franquicias</field>
-            <field name="category_id" ref="base.module_category_accounting_accounting"/>
+            <field name="category_id" ref="module_category_franquicias"/>
             <field name="users" eval="[(4, ref('base.user_admin'))]"/>
         </record>
     </data>


### PR DESCRIPTION
El grupo `group_facturacion_franquicias` colgaba de `base.module_category_accounting_accounting`, que Odoo **fuerza a desplegable de opción única** con un caso especial hardcodeado en `get_groups_by_application()` (`base/models/res_users.py`):

```python
# We want a selection for Accounting too...
if app.xml_id == "base.module_category_accounting_accounting":
    return (app, "selection", gs.sorted(key=order.get), category_name)
```

## El problema

Al ser opción única, el permiso competía con los niveles contables. Y como **ningún grupo de Contabilidad lo implica** —`Administrador de facturación` implica 30 grupos transitivamente, pero no este—, elegir cualquier nivel en ese desplegable **borraba el permiso en silencio**.

En la práctica: una persona no podía tener a la vez un nivel contable y la acción de facturar franquicias. Y "ascender" a alguien a `Administrador de facturación`, que intuitivamente es darle más, le quitaba la acción.

## La solución

Categoría propia `Franquicias`, colgada de `base.module_category_accounting`. Con un solo grupo dentro el orden es total, así que se dibuja como un desplegable de dos opciones, independiente de `Contabilidad`.

Dos detalles que no son obvios y quedaron comentados en el XML:

- **Sin `category_id` no sirve**: los grupos sin categoría van a un bloque que la vista envuelve con `groups="base.group_no_one"`, o sea que solo se ven en modo desarrollador. Se probó y el permiso desapareció de la ficha en modo normal. Quien administra usuarios en FORUM no usa modo dev.
- **El `parent_id` es necesario**: sin padre, `get_groups_by_application()` asigna `(100, "Other")` y el permiso termina en el bloque OTHER en vez de ACCOUNTING.

## Verificado en local (`o17_forum`, 8069)

| Verificación | Resultado |
|---|---|
| Categoría del grupo | Franquicias (hija de Contabilidad) |
| Ubicación en la ficha | línea **Franquicias** dentro del bloque ACCOUNTING |
| Visible sin modo desarrollador | sí |
| Miembros tras el `-u` | conservados |
| Desplegable Contabilidad | los 4 niveles estándar, sin el grupo a medida |
| Coexistencia `Administrador de facturación` + `Franquicias` | sí |
| Errores en `-u` y arranque | ninguno |

Versión del módulo `17.0.1.0.0` → `17.0.1.3.0`, para que el comparador de versiones detecte el drift y no haya que acordarse de un `-u` manual.

## Al mergear

Requiere `-u pos_sale_order_sync_autoinvoice`: el cambio es de datos XML, no de código Python.

Los instructivos de permisos entregados a FORUM ya están actualizados con este comportamiento.